### PR TITLE
Fix lighting glitch in ViewLightSlope_E_UP

### DIFF
--- a/viewlight.inc.c
+++ b/viewlight.inc.c
@@ -103,7 +103,7 @@ ViewLightSlope_E_UP(View *view, int *slopes, int *patterns)
 	else if(FLAT(slopes[TILE_S]))
 		patterns[n++] = 37;
 	if(!(FLAT(slopes[TILE_NW]) || N_OR_W_UP(slopes[TILE_NW]))){
-		if(!FLAT(slopes[TILE_N]))
+		if(FLAT(slopes[TILE_N]))
 			patterns[n++] = 36;
 	}else
 		patterns[n++] = 8;


### PR DESCRIPTION
Inverting this condition for ViewLightSlope_E_UP fixes the weird light patches as seen in this screenshot:

![imgur link](https://i.imgur.com/cvtqU4r.png)

At least, that is how it renders in my program, whose blending/filtering/lighting is largely based on information from your geniedoc repository and code in this one. 
Thanks btw for the awesome work!